### PR TITLE
feat: 支持指定cookie获取知乎热榜

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,7 @@ export type Config = {
   REDIS_HOST: string;
   REDIS_PORT: number;
   REDIS_PASSWORD: string;
+  ZHIHU_COOKIE: string;
 };
 
 // 验证并提取环境变量
@@ -51,4 +52,5 @@ export const config: Config = {
   REDIS_HOST: getEnvVariable("REDIS_HOST") || "127.0.0.1",
   REDIS_PORT: getNumericEnvVariable("REDIS_PORT", 6379),
   REDIS_PASSWORD: getEnvVariable("REDIS_PASSWORD") || "",
+  ZHIHU_COOKIE: getEnvVariable("ZHIHU_COOKIE") || "",
 };

--- a/src/routes/zhihu.ts
+++ b/src/routes/zhihu.ts
@@ -2,6 +2,7 @@ import type { RouterData } from "../types.js";
 import type { RouterType } from "../router.types.js";
 import { get } from "../utils/getData.js";
 import { getTime } from "../utils/getTime.js";
+import { config } from "../config.js"
 
 export const handleRoute = async (_: undefined, noCache: boolean) => {
   const listData = await getList(noCache);
@@ -18,7 +19,15 @@ export const handleRoute = async (_: undefined, noCache: boolean) => {
 
 const getList = async (noCache: boolean) => {
   const url = `https://www.zhihu.com/api/v3/feed/topstory/hot-lists/total?limit=50&desktop=true`;
-  const result = await get({ url, noCache });
+  const result = await get({ 
+      url,
+      noCache,
+      ...(config.ZHIHU_COOKIE && {
+        headers: {
+          Cookie: config.ZHIHU_COOKIE
+        }
+      })
+    });
   const list = result.data.data;
   return {
     ...result,


### PR DESCRIPTION
知乎热榜有登录态鉴权，故新增一个配置项支持传入zhihu的cookie
通过环境变量传入：
> ZHIHU_COOKIE=q_c1=xxxxxyyyyyyyyyyzzzzzz

已进行测试
<img width="293" alt="image" src="https://github.com/user-attachments/assets/05265a0a-a2cd-445d-8871-d0f079d6d9e5" />
