### PR TITLE
修复多源热榜抓取稳定性并规范忽略本地补丁目录

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,8 @@ package-lock.json
 # Sentry Config File
 .env.sentry-build-plugin
 .nvmrc
+
+# Local workspace artifacts
+.planning/
+.pnpm-store/
+补丁/

--- a/src/routes/baidu.ts
+++ b/src/routes/baidu.ts
@@ -1,6 +1,24 @@
 import type { RouterData, ListContext, Options, RouterResType } from "../types.js";
 import { get } from "../utils/getData.js";
 
+/*
+ * ========================= Change Record =========================
+ * [Date]        2026-04-09
+ * [Type]        Bug Fix
+ * [Description] Harden the Baidu route against board HTML changes and align
+ *               source code with the previously validated post-build patch.
+ * [Approach]    Keep the existing resilient s-data parsing, but restore the
+ *               mobile User-Agent and safer URL fallbacks from the tested fix.
+ * [Parameters]  handleRoute(c, noCache): `c` carries the query string, and
+ *               `noCache` bypasses the shared HTTP cache when true.
+ * [Returns]     RouterData for the selected Baidu board, or an empty list when
+ *               the page no longer exposes a parsable payload.
+ * [Impact]      Affects `/baidu` route consumers and build output generated
+ *               from this source file.
+ * [Risk]        Depends on Baidu still embedding `<!--s-data:...-->` in the
+ *               board page; no other known risk.
+ * =================================================================
+ */
 const typeMap: Record<string, string> = {
   realtime: "热搜",
   novel: "小说",
@@ -51,6 +69,23 @@ interface BaiduSData {
   cards?: Array<{ content?: BaiduItem[] }>;
 }
 
+/**
+ * Extracts the actual board list from the nested `s-data` payload.
+ *
+ * The Baidu board payload has changed between `cards` and `data.cards`, and
+ * some responses wrap the final list in an extra `content[0].content` layer.
+ */
+const extractBoardItems = (payload: BaiduSData): BaiduItem[] => {
+  const cardContent = payload.data?.cards?.[0]?.content ?? payload.cards?.[0]?.content;
+  if (!Array.isArray(cardContent)) {
+    return [];
+  }
+  if (cardContent.length > 0 && Array.isArray(cardContent[0]?.content)) {
+    return cardContent[0].content ?? [];
+  }
+  return cardContent;
+};
+
 const getList = async (options: Options, noCache: boolean): Promise<RouterResType> => {
   const { type } = options;
   const url = `https://top.baidu.com/board?tab=${type}`;
@@ -59,10 +94,9 @@ const getList = async (options: Options, noCache: boolean): Promise<RouterResTyp
     noCache,
     headers: {
       "User-Agent":
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 14_2_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/605.1.15",
     },
   });
-  // 正则查找
   const pattern = /<!--s-data:(.*?)-->/s;
   const matchResult = result.data.match(pattern);
   if (!matchResult) {
@@ -73,15 +107,7 @@ const getList = async (options: Options, noCache: boolean): Promise<RouterResTyp
   }
   let jsonObject: BaiduItem[] = [];
   try {
-    const sData: BaiduSData = JSON.parse(matchResult[1]);
-    const cardContent = sData.data?.cards?.[0]?.content ?? sData.cards?.[0]?.content;
-    if (Array.isArray(cardContent)) {
-      if (cardContent.length > 0 && Array.isArray(cardContent[0]?.content)) {
-        jsonObject = cardContent[0].content!;
-      } else {
-        jsonObject = cardContent;
-      }
-    }
+    jsonObject = extractBoardItems(JSON.parse(matchResult[1]) as BaiduSData);
   } catch {
     jsonObject = [];
   }
@@ -97,8 +123,10 @@ const getList = async (options: Options, noCache: boolean): Promise<RouterResTyp
         author: v.show?.length ? v.show : "",
         timestamp: 0,
         hot: parseInt((v.hotScore ?? v.hotTag ?? "0").toString(), 10) || 0,
-        url: `https://www.baidu.com/s?wd=${encodeURIComponent(v.query ?? title)}`,
-        mobileUrl: v.rawUrl ?? v.url ?? "",
+        url: v.query
+          ? `https://www.baidu.com/s?wd=${encodeURIComponent(v.query)}`
+          : (v.url ?? `https://www.baidu.com/s?wd=${encodeURIComponent(title)}`),
+        mobileUrl: v.rawUrl ?? v.url ?? `https://www.baidu.com/s?wd=${encodeURIComponent(title)}`,
       };
     }),
   };

--- a/src/routes/coolapk.ts
+++ b/src/routes/coolapk.ts
@@ -1,6 +1,23 @@
 import type { RouterData } from "../types.js";
 import { get } from "../utils/getData.js";
 import { genHeaders } from "../utils/getToken/coolapk.js";
+import * as cheerio from "cheerio";
+
+/*
+ * ========================= Change Record =========================
+ * [Date]        2026-04-09
+ * [Type]        Bug Fix
+ * [Description] Add a TopHub fallback for Coolapk so the route still returns
+ *               data when the official API is rate-limited or unavailable.
+ * [Approach]    Keep the official API as the preferred path and downgrade to
+ *               a mirrored HTML source only when the API path fails.
+ * [Parameters]  handleRoute(_, noCache): `_` is unused and `noCache` bypasses
+ *               the shared HTTP cache when true.
+ * [Returns]     RouterData for the current Coolapk hot list.
+ * [Impact]      Affects `/coolapk` route consumers and generated dist output.
+ * [Risk]        TopHub fallback depends on a third-party mirror.
+ * =================================================================
+ */
 
 export const handleRoute = async (_: undefined, noCache: boolean) => {
   const listData = await getList(noCache);
@@ -28,26 +45,75 @@ interface CoolapkResponse {
   data: CoolapkItem[];
 }
 
-const getList = async (noCache: boolean) => {
-  const url = `https://api.coolapk.com/v6/page/dataList?url=/feed/statList?cacheExpires=300&statType=day&sortField=detailnum&title=今日热门&title=今日热门&subTitle=&page=1`;
-  const result = await get<CoolapkResponse>({
-    url,
+const TOPHUB_FALLBACK_URL = "https://tophub.today/n/12owD90vNV";
+
+/**
+ * Uses TopHub as the last available source when Coolapk's first-party API is
+ * temporarily blocked or returns an empty payload.
+ */
+const getTopHubFallback = async (noCache: boolean) => {
+  const result = await get<string>({
+    url: TOPHUB_FALLBACK_URL,
     noCache,
-    headers: genHeaders(),
+    responseType: "text",
+    headers: {
+      "User-Agent": "Mozilla/5.0",
+    },
   });
-  const list = result.data.data;
-  return {
-    ...result,
-    data: list.map((v) => ({
-      id: v.id,
-      title: v.message,
-      cover: v.tpic,
-      author: v.username,
-      desc: v.ttitle,
+  const $ = cheerio.load(result.data);
+  const data: RouterData["data"] = [];
+  $(".p-c-m .table a").each((_, element) => {
+    const anchor = $(element);
+    const title = anchor.text().trim().replace(/\s+/g, " ");
+    const href = anchor.attr("href") || "";
+    if (!title || title === "" || !href.startsWith("https://www.coolapk.com/feed/")) {
+      return;
+    }
+    data.push({
+      id: href.split("/").pop() || title,
+      title,
+      cover: undefined,
+      author: undefined,
+      desc: "TopHub fallback",
       timestamp: undefined,
       hot: undefined,
-      url: v.shareUrl,
-      mobileUrl: v.shareUrl,
-    })),
+      url: href,
+      mobileUrl: href,
+    });
+  });
+  return {
+    ...result,
+    data,
   };
+};
+
+const getList = async (noCache: boolean) => {
+  try {
+    const result = await get<CoolapkResponse>({
+      url: `https://api.coolapk.com/v6/page/dataList?url=/feed/statList?cacheExpires=300&statType=day&sortField=detailnum&title=今日热门&title=今日热门&subTitle=&page=1`,
+      noCache,
+      headers: genHeaders(),
+    });
+    const list = result.data?.data;
+    if (Array.isArray(list) && list.length) {
+      return {
+        ...result,
+        data: list.map((item) => ({
+          id: item.id,
+          title: item.message,
+          cover: item.tpic,
+          author: item.username,
+          desc: item.ttitle,
+          timestamp: undefined,
+          hot: undefined,
+          url: item.shareUrl,
+          mobileUrl: item.shareUrl,
+        })),
+      };
+    }
+  } catch {
+    // Intentionally continue to the mirror fallback when the official API is
+    // unavailable in the current environment.
+  }
+  return getTopHubFallback(noCache);
 };

--- a/src/routes/huxiu.ts
+++ b/src/routes/huxiu.ts
@@ -1,7 +1,24 @@
 import type { RouterData } from "../types.js";
+import { get } from "../utils/getData.js";
 import { getTime } from "../utils/getTime.js";
-import axios from "axios";
+import * as cheerio from "cheerio";
 
+/*
+ * ========================= Change Record =========================
+ * [Date]        2026-04-09
+ * [Type]        Bug Fix
+ * [Description] Replace the fragile Huxiu moment API path with HTML parsing
+ *               logic from the validated local patch so the route can survive
+ *               API blocking or response regressions.
+ * [Approach]    Fetch the public moment page with a browser-like User-Agent
+ *               and extract cards from multiple selector variants.
+ * [Parameters]  handleRoute(_, noCache): `_` is unused by this route and
+ *               `noCache` bypasses the shared HTTP cache when true.
+ * [Returns]     RouterData containing parsed Huxiu moments.
+ * [Impact]      Affects `/huxiu` route consumers and generated dist output.
+ * [Risk]        HTML selectors may need refresh if Huxiu redesigns the page.
+ * =================================================================
+ */
 export const handleRoute = async (_: undefined, noCache: boolean) => {
   const listData = await getList(noCache);
   const routeData: RouterData = {
@@ -15,63 +32,48 @@ export const handleRoute = async (_: undefined, noCache: boolean) => {
   return routeData;
 };
 
-interface HuxiuCountInfo {
-  agree_num: number;
-}
-
-interface HuxiuUserInfo {
-  username: string;
-}
-
-interface HuxiuItem {
-  content: string;
-  object_id: string;
-  user_info?: HuxiuUserInfo;
-  publish_time: string;
-  count_info?: HuxiuCountInfo;
-}
-
-interface HuxiuApiResponse {
-  data?: {
-    moment_list?: {
-      datalist?: HuxiuItem[];
-    };
-  };
-}
-
 const getList = async (noCache: boolean) => {
-  // PC 端接口
-  const url = `https://moment-api.huxiu.com/web-v3/moment/feed?platform=www`;
-  const res = await axios.get<HuxiuApiResponse>(url, {
+  const url = `https://www.huxiu.com/moment/`;
+  const result = await get<string>({
+    url,
+    noCache,
+    responseType: "text",
     headers: {
       "User-Agent": "Mozilla/5.0",
-      Referer: "https://www.huxiu.com/moment/",
     },
-    timeout: 10000,
   });
-  const list = res.data?.data?.moment_list?.datalist || [];
+  const $ = cheerio.load(result.data);
+  const data: RouterData["data"] = [];
+  $(".moment-item-wrap").each((_, element) => {
+    const root = $(element);
+    const id = root.attr("id") || "";
+    const author = root.find(".username i").first().text().trim() || root.find(".username").first().text().trim();
+    const userIntro = root.find(".yijuhua").first().text().trim();
+    const contentNode = root
+      .find(".plain-text, .moment-item-desc, .moment-item-content, .article-content, .summary, .line-clamp-6")
+      .first();
+    const title = contentNode.text().trim() || root.find(".moment-item a").first().text().trim();
+    const href = root.find("a[href*='/moment/'], a[href*='/article/']").first().attr("href") || "";
+    const timeText = root.find(".time, .publish-time, .moment-time").first().text().trim();
+    const fullUrl = href
+      ? new URL(href, "https://www.huxiu.com").toString()
+      : `https://www.huxiu.com/moment/${id}.html`;
+    if (!title) {
+      return;
+    }
+    data.push({
+      id: id || fullUrl,
+      title,
+      desc: userIntro,
+      author,
+      timestamp: timeText ? getTime(timeText) : undefined,
+      hot: undefined,
+      url: fullUrl,
+      mobileUrl: fullUrl.replace("https://www.huxiu.com", "https://m.huxiu.com"),
+    });
+  });
   return {
-    fromCache: false,
-    updateTime: new Date().toISOString(),
-    data: list.map((v) => {
-      const content = (v.content || "").replace(/<br\s*\/?>/gi, "\n");
-      const [titleLine, ...rest] = content
-        .split("\n")
-        .map((s: string) => s.trim())
-        .filter(Boolean);
-      const title = titleLine?.replace(/。$/, "") || "";
-      const intro = rest.join("\n");
-      const momentId = v.object_id;
-      return {
-        id: momentId,
-        title,
-        desc: intro,
-        author: v.user_info?.username || "",
-        timestamp: getTime(v.publish_time),
-        hot: v.count_info?.agree_num,
-        url: `https://www.huxiu.com/moment/${momentId}.html`,
-        mobileUrl: `https://m.huxiu.com/moment/${momentId}.html`,
-      };
-    }),
+    ...result,
+    data,
   };
 };

--- a/src/routes/kuaishou.ts
+++ b/src/routes/kuaishou.ts
@@ -2,8 +2,28 @@ import type { ListItem, RouterData } from "../types.js";
 import { get } from "../utils/getData.js";
 import { parseChineseNumber } from "../utils/getNum.js";
 import UserAgent from "user-agents";
+import * as cheerio from "cheerio";
 
 const APOLLO_STATE_PREFIX = "window.__APOLLO_STATE__=";
+const TOPHUB_FALLBACK_URL = "https://tophub.today/n/MZd7PrPerO";
+
+/*
+ * ========================= Change Record =========================
+ * [Date]        2026-04-09
+ * [Type]        Bug Fix
+ * [Description] Add layered fallback logic for Kuaishou so the route still
+ *               returns data when the APOLLO payload or the home page layout
+ *               changes.
+ * [Approach]    Keep APOLLO parsing as the primary path, then fall back to the
+ *               rendered rank list, and finally to TopHub as a last resort.
+ * [Parameters]  handleRoute(_, noCache): `_` is unused and `noCache` bypasses
+ *               the shared HTTP cache when true.
+ * [Returns]     RouterData with the best available Kuaishou hot list.
+ * [Impact]      Affects `/kuaishou` route consumers and generated dist output.
+ * [Risk]        TopHub fallback depends on a third-party mirror remaining
+ *               available; otherwise no known risk.
+ * =================================================================
+ */
 
 export const handleRoute = async (_: undefined, noCache: boolean) => {
   const listData = await getList(noCache);
@@ -33,24 +53,14 @@ interface KuaishouApolloState {
   };
 }
 
-const getList = async (noCache: boolean) => {
-  const url = `https://www.kuaishou.com/?isHome=1`;
-  const userAgent = new UserAgent({
-    deviceCategory: "desktop",
-  });
-  const result = await get<string>({
-    url,
-    noCache,
-    headers: {
-      "User-Agent": userAgent.toString(),
-    },
-  });
+/**
+ * Parses the inlined APOLLO state that powers the home page hot list.
+ */
+const parseApolloList = (html: string): ListItem[] => {
   const listData: ListItem[] = [];
-  // 获取主要内容
-  const html = result.data || "";
   const start = html.indexOf(APOLLO_STATE_PREFIX);
   if (start === -1) {
-    throw new Error("快手页面结构变更，未找到 APOLLO_STATE");
+    throw new Error("Kuaishou APOLLO_STATE not found");
   }
   const scriptSlice = html.slice(start + APOLLO_STATE_PREFIX.length);
   const sentinelA = scriptSlice.indexOf(";(function(");
@@ -58,12 +68,11 @@ const getList = async (noCache: boolean) => {
   const cutIndex =
     sentinelA !== -1 && sentinelB !== -1 ? Math.min(sentinelA, sentinelB) : Math.max(sentinelA, sentinelB);
   if (cutIndex === -1) {
-    throw new Error("快手页面结构变更，未找到 APOLLO_STATE 结束标记");
+    throw new Error("Kuaishou APOLLO_STATE end marker not found");
   }
   const raw = scriptSlice.slice(0, cutIndex).trim().replace(/;$/, "");
   let jsonObject: KuaishouApolloState;
   try {
-    // 快手返回的 JSON 末尾常带 undefined/null，需要截断到最后一个 '}' 出现
     const lastBrace = raw.lastIndexOf("}");
     const cleanRaw = lastBrace !== -1 ? raw.slice(0, lastBrace + 1) : raw;
     jsonObject = JSON.parse(cleanRaw)["defaultClient"];
@@ -74,15 +83,12 @@ const getList = async (noCache: boolean) => {
         : "未知错误";
     throw new Error(`快手数据解析失败: ${msg}`);
   }
-  // 获取所有分类
   const allItems =
     jsonObject['$ROOT_QUERY.visionHotRank({"page":"home"})']?.items ||
     jsonObject['$ROOT_QUERY.visionHotRank({"page":"home","platform":"web"})']
       ?.items ||
     [];
-  // 获取全部热榜
   allItems.forEach((item: { id: string }) => {
-    // 基础数据
     const hotItem = jsonObject[item.id];
     if (!hotItem) return;
     const id = hotItem.photoIds?.json?.[0];
@@ -94,12 +100,110 @@ const getList = async (noCache: boolean) => {
       cover: poster,
       hot: parseChineseNumber(String(hotValue)),
       timestamp: undefined,
-      url: `https://www.kuaishou.com/short-video/${id}`,
-      mobileUrl: `https://www.kuaishou.com/short-video/${id}`,
+      url: id
+        ? `https://www.kuaishou.com/short-video/${id}`
+        : `https://www.kuaishou.com/search/${encodeURIComponent(hotItem.name || "")}`,
+      mobileUrl: id
+        ? `https://www.kuaishou.com/short-video/${id}`
+        : `https://www.kuaishou.com/search/${encodeURIComponent(hotItem.name || "")}`,
+    });
+  });
+  return listData;
+};
+
+/**
+ * Falls back to the rendered rank DOM when the embedded APOLLO payload changes.
+ */
+const parseRenderedRankList = (html: string): ListItem[] => {
+  const $ = cheerio.load(html);
+  const listData: ListItem[] = [];
+  $(".rank-container .rank-item").each((_, element) => {
+    const root = $(element);
+    const anchor = root.find("a.rank-name").first();
+    const title = anchor.text().trim();
+    const href = anchor.attr("href") || "";
+    const hotText = root.find(".rank-detail").text().trim();
+    if (!title) {
+      return;
+    }
+    const fullUrl = href
+      ? new URL(href, "https://www.kuaishou.com").toString()
+      : `https://www.kuaishou.com/search/${encodeURIComponent(title)}`;
+    listData.push({
+      id: title,
+      title,
+      cover: undefined,
+      hot: parseChineseNumber(hotText || "0"),
+      timestamp: undefined,
+      url: fullUrl,
+      mobileUrl: fullUrl,
+    });
+  });
+  return listData;
+};
+
+/**
+ * Uses TopHub as the final fallback when both first-party Kuaishou paths fail.
+ */
+const getTopHubFallback = async (noCache: boolean) => {
+  const result = await get<string>({
+    url: TOPHUB_FALLBACK_URL,
+    noCache,
+    responseType: "text",
+    headers: {
+      "User-Agent": "Mozilla/5.0",
+    },
+  });
+  const $ = cheerio.load(result.data);
+  const listData: ListItem[] = [];
+  $(".p-c-m .table a").each((_, element) => {
+    const anchor = $(element);
+    const title = anchor.text().trim().replace(/\s+/g, " ");
+    const href = anchor.attr("href") || "";
+    if (!title || title === "" || href.includes("tophub.today") || href.startsWith("javascript:")) {
+      return;
+    }
+    listData.push({
+      id: title,
+      title,
+      cover: undefined,
+      hot: undefined,
+      timestamp: undefined,
+      url: href,
+      mobileUrl: href,
     });
   });
   return {
     ...result,
     data: listData,
   };
+};
+
+const getList = async (noCache: boolean) => {
+  const url = `https://www.kuaishou.com/?isHome=1`;
+  const userAgent = new UserAgent({
+    deviceCategory: "desktop",
+  });
+  try {
+    const result = await get<string>({
+      url,
+      noCache,
+      responseType: "text",
+      headers: {
+        "User-Agent": userAgent.toString(),
+      },
+    });
+    const apolloData = parseApolloList(result.data || "");
+    const htmlData = apolloData.length ? apolloData : parseRenderedRankList(result.data || "");
+    if (htmlData.length) {
+      return {
+        ...result,
+        data: htmlData,
+      };
+    }
+  } catch {
+    // Intentionally continue to the external fallback because Kuaishou
+    // frequently changes the embedded state and rank DOM structure.
+  }
+  return getTopHubFallback(noCache);
 };

--- a/src/routes/weibo.ts
+++ b/src/routes/weibo.ts
@@ -1,7 +1,23 @@
 import type { RouterData } from "../types.js";
 import { get } from "../utils/getData.js";
 import { getTime } from "../utils/getTime.js";
-import { config } from "../config";
+import * as cheerio from "cheerio";
+
+/*
+ * ========================= Change Record =========================
+ * [Date]        2026-04-09
+ * [Type]        Bug Fix
+ * [Description] Switch Weibo hot search fetching to the mobile endpoint and
+ *               add a TopHub fallback to survive web endpoint instability.
+ * [Approach]    Prefer the tested mobile API payload, then parse TopHub links
+ *               if Weibo blocks or changes the primary response.
+ * [Parameters]  handleRoute(_, noCache): `_` is unused and `noCache` bypasses
+ *               the shared HTTP cache when true.
+ * [Returns]     RouterData for the current Weibo hot list.
+ * [Impact]      Affects `/weibo` route consumers and generated dist output.
+ * [Risk]        The mobile API contract is unofficial and may change.
+ * =================================================================
+ */
 
 export const handleRoute = async (_: undefined, noCache: boolean) => {
   const listData = await getList(noCache);
@@ -18,50 +34,98 @@ export const handleRoute = async (_: undefined, noCache: boolean) => {
 };
 
 interface WeiboItem {
+  itemid?: string;
   mid?: string;
-  word?: string;
+  desc?: string;
   word_scheme?: string;
-  onboard_time?: number;
+  onboard_time?: number | string;
+  scheme?: string;
 }
 
 interface WeiboResponse {
   data?: {
-    realtime: WeiboItem[];
+    cards?: Array<{
+      card_group?: WeiboItem[];
+    }>;
   };
 }
 
-const getList = async (noCache: boolean) => {
-  const url = "https://weibo.com/ajax/side/hotSearch";
+const TOPHUB_FALLBACK_URL = "https://tophub.today/n/KqndgxeLl9";
 
-  const result = await get<WeiboResponse>({
-    url,
+/**
+ * Uses TopHub as a degraded but stable response source when Weibo blocks the
+ * mobile endpoint or changes its response shape.
+ */
+const getTopHubFallback = async (noCache: boolean) => {
+  const result = await get<string>({
+    url: TOPHUB_FALLBACK_URL,
     noCache,
-    ttl: 60,
+    responseType: "text",
     headers: {
-      Referer: "https://weibo.com/",
-      "User-Agent":
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
+      "User-Agent": "Mozilla/5.0",
     },
   });
-
-  if (!result.data?.data?.realtime) {
-    return { ...result, data: [] };
-  }
-
-  const list = result.data.data.realtime;
+  const $ = cheerio.load(result.data);
+  const data: RouterData["data"] = [];
+  $(".p-c-m .table a").each((_, element) => {
+    const anchor = $(element);
+    const title = anchor.text().trim().replace(/\s+/g, " ");
+    const href = anchor.attr("href") || "";
+    if (!title || title === "" || !href.startsWith("https://s.weibo.com/weibo?q=")) {
+      return;
+    }
+    data.push({
+      id: title,
+      title,
+      desc: title,
+      timestamp: undefined,
+      hot: undefined,
+      url: href,
+      mobileUrl: href,
+    });
+  });
   return {
     ...result,
-    data: list.map((v, index: number) => {
-      const title = v.word || v.word_scheme || `热搜${index + 1}`;
-      return {
-        id: v.mid || v.word_scheme || `weibo-${index}`,
-        title: title,
-        desc: v.word_scheme || `#${title}#`,
-        hot: undefined,
-        timestamp: getTime(v.onboard_time || Date.now()),
-        url: `https://s.weibo.com/weibo?q=${encodeURIComponent(title)}`,
-        mobileUrl: `https://s.weibo.com/weibo?q=${encodeURIComponent(title)}`,
-      };
-    }),
+    data,
   };
+};
+
+const getList = async (noCache: boolean) => {
+  try {
+    const result = await get<WeiboResponse>({
+      url: "https://m.weibo.cn/api/container/getIndex?containerid=106003type%3D25%26t%3D3%26disable_hot%3D1%26filter_type%3Drealtimehot&title=%E5%BE%AE%E5%8D%9A%E7%83%AD%E6%90%9C&extparam=filter_type%3Drealtimehot%26mi_cid%3D100103%26pos%3D0_0%26c_type%3D30%26display_time%3D1540538388&luicode=10000011&lfid=231583",
+      noCache,
+      ttl: 60,
+      headers: {
+        Referer: "https://s.weibo.com/top/summary?cate=realtimehot",
+        "MWeibo-Pwa": "1",
+        "X-Requested-With": "XMLHttpRequest",
+        "User-Agent":
+          "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1",
+      },
+    });
+    const list = result.data?.data?.cards?.[0]?.card_group;
+    if (Array.isArray(list) && list.length) {
+      return {
+        ...result,
+        data: list.map((item, index) => {
+          const title = item.desc || `热搜${index + 1}`;
+          const keyword = item.word_scheme || `#${title}`;
+          return {
+            id: item.itemid || item.mid || `weibo-${index}`,
+            title,
+            desc: keyword,
+            timestamp: item.onboard_time ? getTime(item.onboard_time) : undefined,
+            hot: undefined,
+            url: `https://s.weibo.com/weibo?q=${encodeURIComponent(keyword)}&t=31&band_rank=1&Refer=top`,
+            mobileUrl: item.scheme || `https://s.weibo.com/weibo?q=${encodeURIComponent(keyword)}`,
+          };
+        }),
+      };
+    }
+  } catch {
+    // Intentionally continue to the mirror fallback when the primary endpoint
+    // is rate-limited or returns an unexpected schema.
+  }
+  return getTopHubFallback(noCache);
 };


### PR DESCRIPTION
## 变更说明

本次修改将此前仅覆盖 `dist/routes/*.js` 的本地补丁，正式迁回源码层的 TypeScript 路由实现，避免重新构建后补丁失效，并提升多个热榜源在接口变动或风控场景下的可用性。

### 主要改动

- 修复 `baidu` 路由：增强 `s-data` 解析兼容性，并补充更稳的链接兜底逻辑
- 修复 `huxiu` 路由：由脆弱 API 切换为页面 HTML 解析
- 修复 `kuaishou` 路由：保留 APOLLO 主链路，并增加 DOM fallback 与 TopHub fallback
- 修复 `weibo` 路由：切换为移动端接口，并在失败时回退到 TopHub
- 修复 `coolapk` 路由：保留官方 API，并在失败时回退到 TopHub
- 补充 `.gitignore`：忽略 `.planning/`、`.pnpm-store/`、`补丁/` 等本地工作目录产物

## 验证结果

已在本地完成以下验证：

- `pnpm lint`
- `pnpm build`
- smoke test：`baidu` / `huxiu` / `kuaishou` / `weibo` / `coolapk`

## 备注

- 本地验证环境未启用 Redis，日志中会出现 Redis 连接失败提示，但不影响 NodeCache 兜底与接口返回
- `weibo`、`coolapk` 在当前验证环境中主要通过 fallback 链路返回数据，说明降级逻辑已生效