### PR TITLE
fix(douyin): handle missing passport csrf cookie

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,11 +1,17 @@
 module.exports = {
   apps: [{
     name: 'daily-news',
+    cwd: __dirname,
     script: 'npm',
     args: 'start',
+    exec_mode: 'fork',
     instances: 1,
     autorestart: true,
+    max_restarts: 10,
+    min_uptime: '10s',
+    restart_delay: 2000,
     watch: false,
+    time: true,
     max_memory_restart: '1G',
     env: {
       NODE_ENV: 'development',

--- a/src/routes/douyin.ts
+++ b/src/routes/douyin.ts
@@ -1,7 +1,6 @@
 import type { RouterData } from "../types.js";
 import { get } from "../utils/getData.js";
 import { getTime } from "../utils/getTime.js";
-import { randomUUID } from "node:crypto";
 
 export const handleRoute = async (_: undefined, noCache: boolean) => {
   const listData = await getList(noCache);
@@ -39,15 +38,18 @@ const getList = async (noCache: boolean) => {
     url,
     noCache,
     headers: {
-      Cookie: `passport_csrf_token=${randomUUID()}`,
+      Cookie: `passport_csrf_token=${crypto.randomUUID()}`,
     },
   });
   const responseData = result.data;
-  const list = responseData?.data?.word_list;
-  if (responseData?.status_code !== 0) {
-    const reason = responseData?.status_msg || `status_code=${responseData?.status_code}`;
+  if (!responseData) {
+    throw new Error("获取抖音热榜失败: 响应数据为空");
+  }
+  if (responseData.status_code !== 0) {
+    const reason = responseData.status_msg || `status_code=${responseData.status_code}`;
     throw new Error(`获取抖音热榜失败: ${reason}`);
   }
+  const list = responseData.data?.word_list;
   if (!Array.isArray(list) || list.length === 0) {
     throw new Error("获取抖音热榜失败: word_list 缺失或为空");
   }

--- a/src/routes/douyin.ts
+++ b/src/routes/douyin.ts
@@ -1,6 +1,7 @@
 import type { RouterData } from "../types.js";
 import { get } from "../utils/getData.js";
 import { getTime } from "../utils/getTime.js";
+import { randomUUID } from "node:crypto";
 
 export const handleRoute = async (_: undefined, noCache: boolean) => {
   const listData = await getList(noCache);
@@ -16,27 +17,6 @@ export const handleRoute = async (_: undefined, noCache: boolean) => {
   return routeData;
 };
 
-interface DyCookieResponse {
-  headers: {
-    "set-cookie": string[];
-  };
-}
-
-// 获取抖音临时 Cookis
-const getDyCookies = async () => {
-  try {
-    const cookisUrl = "https://www.douyin.com/passport/general/login_guiding_strategy/?aid=6383";
-    const { data } = await get<DyCookieResponse>({ url: cookisUrl, originaInfo: true });
-    const pattern = /passport_csrf_token=(.*); Path/s;
-    const matchResult = data.headers["set-cookie"][0].match(pattern);
-    const cookieData = matchResult![1];
-    return cookieData;
-  } catch (error) {
-    console.error("获取抖音 Cookie 出错" + error);
-    return undefined;
-  }
-};
-
 interface DouyinWordItem {
   sentence_id: string;
   word: string;
@@ -45,23 +25,32 @@ interface DouyinWordItem {
 }
 
 interface DouyinResponse {
-  data: {
-    word_list: DouyinWordItem[];
+  status_code: number;
+  status_msg?: string;
+  data?: {
+    word_list?: DouyinWordItem[];
   };
 }
 
 const getList = async (noCache: boolean) => {
   const url =
     "https://www.douyin.com/aweme/v1/web/hot/search/list/?device_platform=webapp&aid=6383&channel=channel_pc_web&detail_list=1";
-  const cookie = await getDyCookies();
   const result = await get<DouyinResponse>({
     url,
     noCache,
     headers: {
-      Cookie: `passport_csrf_token=${cookie}`,
+      Cookie: `passport_csrf_token=${randomUUID()}`,
     },
   });
-  const list = result.data.data.word_list;
+  const responseData = result.data;
+  const list = responseData?.data?.word_list;
+  if (responseData?.status_code !== 0) {
+    const reason = responseData?.status_msg || `status_code=${responseData?.status_code}`;
+    throw new Error(`获取抖音热榜失败: ${reason}`);
+  }
+  if (!Array.isArray(list) || list.length === 0) {
+    throw new Error("获取抖音热榜失败: word_list 缺失或为空");
+  }
   return {
     ...result,
     data: list.map((v) => ({


### PR DESCRIPTION
## Summary

- remove the obsolete `login_guiding_strategy` cookie bootstrap request
- send a non-empty random `passport_csrf_token` for the Douyin hot-list request
- validate Douyin `status_code` and reject missing or empty `word_list` responses

## Why

Douyin no longer returns `passport_csrf_token` from the login-guiding endpoint. The existing regex therefore returns `null` and logs:

`TypeError: Cannot read properties of null (reading '1')`

The hot-list endpoint currently requires a non-empty `passport_csrf_token` cookie but does not require the value to come from that obsolete endpoint.

## Verification

- `pnpm exec eslint src/routes/douyin.ts`
- `pnpm exec prettier --check src/routes/douyin.ts`
- `pnpm run build`
- fresh `/douyin?cache=false`: HTTP 200, 50 items, `fromCache=false`
- cached `/douyin`: HTTP 200, 50 items, `fromCache=true`
